### PR TITLE
Fixed SELL BUY Mode for GetCryptoCurrencies

### DIFF
--- a/src/Domains/Currencies/GetCryptoCurrencies.php
+++ b/src/Domains/Currencies/GetCryptoCurrencies.php
@@ -41,7 +41,7 @@ class GetCryptoCurrencies extends Domain
      */
     public function setBuyMode(): static
     {
-        $this->mode = self::SELL_MODE;
+        $this->mode = self::BUY_MODE;
         return $this;
     }
 
@@ -50,7 +50,7 @@ class GetCryptoCurrencies extends Domain
      */
     public function setSellMode(): static
     {
-        $this->mode = self::BUY_MODE;
+        $this->mode = self::SELL_MODE;
         return $this;
     }
 }


### PR DESCRIPTION
Repaired wrong implementation of getCrypto currencies for SELL BUY mode split.